### PR TITLE
Update jsKeyboard.js

### DIFF
--- a/jsKeyboard.js
+++ b/jsKeyboard.js
@@ -157,11 +157,11 @@ var jsKeyboard = {
     },
     writeSpecial: function (m) {
         var a = jsKeyboard.currentElement.val(),
-            b = String.fromCharCode(m),
+            b = m,
             pos = jsKeyboard.currentElementCursorPosition,
             output = [a.slice(0, pos), b, a.slice(pos)].join('');
         jsKeyboard.currentElement.val(output);
-        jsKeyboard.currentElementCursorPosition++; //+1 cursor
+        jsKeyboard.currentElementCursorPosition += b.length; //+n cursor
         jsKeyboard.updateCursor();
     },
     show: function () {


### PR DESCRIPTION
Fixed writeSpecial(m) method. Currently is used for "euro" sign only and it wasn't working. Also, cursor position has to change to N, depending on "m" parameter lenght.
